### PR TITLE
Added setup and teardown for fuzzers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" } # wil
 your_crate = "*" # or something
 ```
 
-and change the `src/main.rs` to fuzz your code:
+and change the `src/main.rs` to fuzz your code (and add any optional setup/teardown code, such as starting/shutting down server thread):
 
 ```rust
 #![no_main]
@@ -35,6 +35,14 @@ and change the `src/main.rs` to fuzz your code:
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate your_crate;
+
+fuzz_setup!({
+    // Enter your setup here.
+});
+
+fuzz_teardown!({
+    // Enter your teardown here.
+});
 
 fuzz_target!(|data: &[u8]| {
     // code to fuzz goes here

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -3,6 +3,14 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 
+fuzz_setup!({
+    // Enter your setup here.
+});
+
+fuzz_teardown!({
+    // Enter your teardown here.
+});
+
 fuzz_target!(|data| {
     if data == b"banana" {
         panic!("success!");

--- a/llvm/lib/Fuzzer/FuzzerMain.cpp
+++ b/llvm/lib/Fuzzer/FuzzerMain.cpp
@@ -14,8 +14,19 @@
 extern "C" {
 // This function should be defined by the user.
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+
+// This function should be defined by the user.
+void LLVMFuzzerSetup(void);
+
+// This function should be defined by the user.
+void LLVMFuzzerTeardown(void);
 }  // extern "C"
 
 int main(int argc, char **argv) {
-  return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+
+  LLVMFuzzerSetup();
+  auto res = fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+  LLVMFuzzerTeardown();
+
+  return res;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ extern "C" {
     #![allow(improper_ctypes)] // we do not actually cross the FFI bound here
 
     fn rust_fuzzer_test_input(input: &[u8]);
+    fn rust_fuzzer_setup();
+    fn rust_fuzzer_teardown();
 }
 
 #[export_name="LLVMFuzzerTestOneInput"]
@@ -13,6 +15,20 @@ pub fn test_input_wrap(data: *const u8, size: usize) -> i32 {
         rust_fuzzer_test_input(data_slice);
     }).err().map(|_| ::std::process::abort());
     0
+}
+
+#[export_name="LLVMFuzzerSetup"]
+pub fn test_setup_wrap() -> () {
+    unsafe {
+        rust_fuzzer_setup()
+    }
+}
+
+#[export_name="LLVMFuzzerTeardown"]
+pub fn test_teardown_wrap() -> () {
+    unsafe {
+        rust_fuzzer_teardown()
+    }
 }
 
 #[macro_export]
@@ -26,6 +42,26 @@ macro_rules! fuzz_target {
     (|$bytes:ident: &[u8]| $body:block) => {
         #[no_mangle]
         pub extern fn rust_fuzzer_test_input($bytes: &[u8]) {
+            $body
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! fuzz_setup {
+    ($body: block) => {
+        #[no_mangle]
+        pub extern fn rust_fuzzer_setup() {
+            $body
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! fuzz_teardown {
+    ($body: block) => {
+        #[no_mangle]
+        pub extern fn rust_fuzzer_teardown() {
             $body
         }
     }


### PR DESCRIPTION
Added fuzz_setup and fuzz_teardown macros, where setup and teardown lambdas can be detailed  in order to e.g. start and stop a server thread that is to be subject to fuzzing.