### PR TITLE
Add env var to select c++ std lib

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,17 +9,11 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", custom_lib_dir);
         println!("cargo:rustc-link-lib=static={}", custom_lib_name);
 
-        // Allow user to specify use of LLVM or GCC C++ stdlib, or none.
-        // "cargo:rustc-link-lib=stdc++" is used by default for
-        // backward-compatibility.
-        // Note: google/oss-fuzz uses LLVM C++ stdlib as of 15 Jan 2020
-        if let Ok(std_cxx_flag) = ::std::env::var("CUSTOM_LIBFUZZER_STD_CXX") {
-            match std_cxx_flag.as_str() {
-                "c++" => println!("cargo:rustc-link-lib=c++"),
-                "stdc++" => println!("cargo:rustc-link-lib=stdc++"),
-                "none" => (),
-                _ => println!("cargo:rustc-link-lib=stdc++"),
-            }
+        match std::env::var("CUSTOM_LIBFUZZER_STD_CXX") {
+            // Default behavior for backwards compat.
+            Err(_) => println!("cargo:rustc-link-lib=stdc++"),
+            Ok(s) if s == "none" => (),
+            Ok(s) => println!("cargo:rustc-link-lib={}", s),
         }
     } else {
         let mut build = cc::Build::new();

--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,19 @@ fn main() {
 
         println!("cargo:rustc-link-search=native={}", custom_lib_dir);
         println!("cargo:rustc-link-lib=static={}", custom_lib_name);
-        /* FIXME: this is assuming a C++ fuzzer, but should be customizable */
-        println!("cargo:rustc-link-lib=stdc++");
+
+        // Allow user to specify use of LLVM or GCC C++ stdlib, or none.
+        // "cargo:rustc-link-lib=stdc++" is used by default for
+        // backward-compatibility.
+        // Note: google/oss-fuzz uses LLVM C++ stdlib as of 15 Jan 2020
+        if let Ok(std_cxx_flag) = ::std::env::var("CUSTOM_LIBFUZZER_STD_CXX") {
+            match std_cxx_flag.as_str() {
+                "c++" => println!("cargo:rustc-link-lib=c++"),
+                "stdc++" => println!("cargo:rustc-link-lib=stdc++"),
+                "none" => (),
+                _ => println!("cargo:rustc-link-lib=stdc++"),
+            }
+        }
     } else {
         let mut build = cc::Build::new();
         let sources = ::std::fs::read_dir("libfuzzer")


### PR DESCRIPTION
Apologies in advance for this hack job.

As part of https://github.com/bytecodealliance/wasmtime/issues/611 I am building wasmtime fuzz targets in the google/oss-fuzz build container. This environment supplies the LLVM c++ standard library rather than the GCC one. It is specified in `CXXFLAGS` and presumably linked in the version of libfuzzer they supplied (`libFuzzingEngine.a`).

It looks like rust-fuzz/libfuzzer currently [links the GCC standard library when using an external libfuzzer library](https://github.com/rust-fuzz/libfuzzer/blob/cc49a08fd7c20b669b4491f6c61054c570eedda0/build.rs#L12), which causes a linker error when linking in the oss-fuzz compilation environment.

This PR adds an environment variable that lets the user select whether they'd like to link the GCC c++ standard library (the default, for backward compatibility), the installed (LLVM) c++ standard library, or not link one at all. If you'd rather control this another way or do something different please feel free.

I wasn't able to easily test rust-fuzz/libfuzzer with the wasmtime fuzz targets due to an incompatibility with the `arbitrary` crate; I didn't attempt to resolve this as part of this PR. I smoke-tested this change by using an old version of libfuzzer, before `arbitrary` was upgraded (actually https://github.com/rust-fuzz/libfuzzer/commit/0c4507533a79e85e1984f59765bdd35fbdaa7f1b, the last functional commit made to rust-fuzz/libfuzzer-sys, which is what I was developing against before I realized it was deprecated : ).

Please let me know how you'd like to proceed -- thanks!