### PR TITLE
Tell users to use inline-8bit-counters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Build by running the following command:
 $ cargo rustc -- \
     -C passes='sancov' \
     -C llvm-args='-sanitizer-coverage-level=3' \
+    -C llvm-args='-sanitizer-coverage-inline-8bit-counters' \
     -Z sanitizer=address
 ```
 


### PR DESCRIPTION
libfuzzer defaults to `trace-pc-guard`, but that seems to be removed
now:

- https://github.com/rust-fuzz/libfuzzer/issues/66
- ~https://github.com/llvm/llvm-project/commit/c5d3d490340fd32698ef9f29b80e97a4c1e95d11#diff-32378db1cb0e8e11ecfc62eda7181acadc661910d4e3ab214babb65af95bc7e9~ meant to link to https://github.com/llvm/llvm-project/commit/62d727061053dac28447a900fce064c54d366bd6

And confusingly, their docs still mention `trace-pc-guard`:

- https://github.com/llvm/llvm-project/blob/master/clang/docs/SanitizerCoverage.rst