### PR TITLE
Remove usage of sanitizer-coverage-level=4

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,7 +10,7 @@ cargo rustc \
       --release \
       -- \
       -Cpasses='sancov' \
-      -Cllvm-args=-sanitizer-coverage-level=4 \
+      -Cllvm-args=-sanitizer-coverage-level=3 \
       -Cllvm-args=-sanitizer-coverage-trace-compares \
       -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
       -Cllvm-args=-sanitizer-coverage-stack-depth \
@@ -25,7 +25,7 @@ cargo rustc \
       --release \
       -- \
       -Cpasses='sancov' \
-      -Cllvm-args=-sanitizer-coverage-level=4 \
+      -Cllvm-args=-sanitizer-coverage-level=3 \
       -Cllvm-args=-sanitizer-coverage-trace-compares \
       -Cllvm-args=-sanitizer-coverage-inline-8bit-counters \
       -Cllvm-args=-sanitizer-coverage-stack-depth \


### PR DESCRIPTION
Level 4 seems to have been removed in:

https://github.com/llvm/llvm-project/commit/c5d3d490340fd32698ef9f29b80e97a4c1e95d11#diff-32378db1cb0e8e11ecfc62eda7181acadc661910d4e3ab214babb65af95bc7e9