### PR TITLE
Don't rely on libfuzzer-provided entrypoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,8 @@ arbitrary = "0.4.6"
 cc = "1.0"
 
 [features]
+default = []
 arbitrary-derive = ["arbitrary/derive"]
+# Define the `main` entrypoint in this library. If not specified, the entrypoint is still available
+# as libfuzzer_main
+entrypoint = []


### PR DESCRIPTION
So, this can definitely work without changes to libfuzzer itself, as it
is written today. There are a couple pieces to it:

1. Don't compile `FuzzerMain.cpp` at all;
2. Use `LLVMFuzzerRunDriver` defined in `FuzzerDriver.cpp` to kick off
the fuzzing process in the macro.

I think with those and something like the `inventory` crate we also open
ourselves to having interface that's more like `libtest`.

That said, `LLVMFuzzerRunDriver` requires `argc` and `argv`, which at
that point requires one to manually convert them back into C layout from
`std::env::args_os`.

I also don't believe this change is meaningful as is, without an
otherwise major rework of the libfuzzer API. It doesn't achieve
anything much as it is, and only serves to complicate the implementation
of libfuzzer crate itself.

cc #46 