### PR TITLE
Make RUST_LIBFUZZER_DEBUG_PATH "free" for non-users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.4.1"
 
 [dependencies]
 arbitrary = "1"
+once_cell = "1"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ macro_rules! fuzz_target {
         /// Auto-generated function
         #[no_mangle]
         pub extern "C" fn rust_fuzzer_test_input(bytes: &[u8]) {
-            use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+            use $crate::arbitrary::{Arbitrary, Unstructured};
 
             // Early exit if we don't have enough bytes for the `Arbitrary`
             // implementation. This helps the fuzzer avoid exploring all the


### PR DESCRIPTION
Currently if someone doesn't use `RUST_LIBFUZZER_DEBUG_PATH` they still need to pay an allocation (to convert to `CString`) a Mutex lock, and a `getenv(3)` call for every fuzzing input.

Instead we can check and load the environment variable at initialization and from then it will be almost free for users that don't set the environment variable.

(this is slightly a behavior change as before someone could attach a debugger and modify the enviroment variable while it's fuzzing but now they can't, but I don't think it matters)