### PR TITLE
Use absolute path to fuzz_target! macro in macro recursion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ macro_rules! fuzz_target {
     };
 
     (|$data:ident: &[u8]| $body:block) => {
-        fuzz_target!(|$data| $body);
+        $crate::fuzz_target!(|$data| $body);
     };
 
     (|$data:ident: $dty: ty| $body:block) => {


### PR DESCRIPTION
For fuzz targets that use `libfuzzer_sys::fuzz_target!(|arg: &[u8]| {})` directly without `#[macro_use]`ing `libfuzzer_sys`, the compilation failed:

```
error: cannot find macro `fuzz_target` in this scope
   --> [$HOME]/.cargo/registry/src/github.com-1ecc6299db9ec823/libfuzzer-sys-0.4.2/src/lib.rs:161:9
    |
137 | / macro_rules! fuzz_target {
138 | |     (|$bytes:ident| $body:block) => {
139 | |         /// Auto-generated function
140 | |         #[no_mangle]
...   |
161 | |         fuzz_target!(|$data| $body);
    | |         ^^^^^^^^^^^
...   |
207 | |     };
208 | | }
    | |_- in this expansion of `libfuzzer_sys::fuzz_target!`
    |
   ::: fuzz_targets/bare.rs:3:1
    |
3   | / libfuzzer_sys::fuzz_target!(|data: &[u8]| {
4   | |     // fuzzed code goes here
5   | | });
    | |___- in this macro invocation
    |
    = note: consider importing this macro:
            libfuzzer_sys::fuzz_target
```