### PR TITLE
fix(libfuzzer): add cstddef for size_t

### DIFF
--- a/libfuzzer/FuzzerInterceptors.cpp
+++ b/libfuzzer/FuzzerInterceptors.cpp
@@ -25,6 +25,7 @@
   }
 
 #include <cassert>
+#include <cstddef> // for size_t
 #include <cstdint>
 #include <dlfcn.h> // for dlsym()
 


### PR DESCRIPTION
Add missing `cstddef` header for `size_t`.  
Fixes https://github.com/rust-fuzz/libfuzzer/issues/87  
libfuzzer code is then up-to-date with llvm branch release/13.x up to 2022/01/20.  
Upstream fix is with https://github.com/llvm/llvm-project/commit/60e32a1f34e9ea60155a98bbe6ee5ec2a383efa3