### PR TITLE
Enable keep/reject inputs from the corpus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub fn initialize(_argc: *const isize, _argv: *const *const *const u8) -> isize 
 ///     let value = parts[1];
 ///     let _result: Result<_, _> = my_crate::parse(key, value);
 ///     Corpus::Keep
-/// );
+/// });
 /// # mod my_crate { pub fn parse(_key: &str, _value: &str) -> Result<(), ()> { unimplemented!() } }
 /// ```
 ///
@@ -218,7 +218,7 @@ macro_rules! fuzz_target {
                         .expect("failed to create `RUST_LIBFUZZER_DEBUG_PATH` file");
                     writeln!(&mut file, "{:?}", bytes)
                         .expect("failed to write to `RUST_LIBFUZZER_DEBUG_PATH` file");
-                    return;
+                    return 0;
                 }
 
                 run(bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub fn initialize(_argc: *const isize, _argv: *const *const *const u8) -> isize 
 /// from the corpus, return either [Corpus::Keep] or [Corpus::Reject] from your
 /// fuzz target. The default behavior (e.g. if `()` is returned) is to keep the
 /// input in the corpus.
-/// 
+///
 /// For example:
 ///
 /// ```no_run


### PR DESCRIPTION
This allows the fuzz target to indiciate whether an input was useful for the fuzz testing by returning Corpus::Keep or Corpus::Reject. Backwards compatibility is preserved by coercing the unit type () to Corpus::Keep.

This maps to 0 (Keep) and -1 (Reject) in the libFuzzer API: https://llvm.org/docs/LibFuzzer.html#rejecting-unwanted-inputs