### PR TITLE
Fix minor build.rs issues w.r.t. custom libfuzzer paths

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=CUSTOM_LIBFUZZER_PATH");
     if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
+        println!("cargo:rerun-if-changed={custom}");
+
         let custom_lib_path = ::std::path::PathBuf::from(&custom);
         let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
 

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,11 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=CUSTOM_LIBFUZZER_PATH");
     if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
         let custom_lib_path = ::std::path::PathBuf::from(&custom);
         let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
 
         let custom_lib_name = custom_lib_path.file_stem().unwrap().to_string_lossy();
-        let custom_lib_name = custom_lib_name.trim_start_matches("lib");
+        let custom_lib_name = custom_lib_name.strip_prefix("lib").unwrap_or(custom_lib_name.as_ref());
 
         println!("cargo:rustc-link-search=native={}", custom_lib_dir);
         println!("cargo:rustc-link-lib=static={}", custom_lib_name);

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,9 @@ fn main() {
         let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
 
         let custom_lib_name = custom_lib_path.file_stem().unwrap().to_string_lossy();
-        let custom_lib_name = custom_lib_name.strip_prefix("lib").unwrap_or(custom_lib_name.as_ref());
+        let custom_lib_name = custom_lib_name
+            .strip_prefix("lib")
+            .unwrap_or(custom_lib_name.as_ref());
 
         println!("cargo:rustc-link-search=native={}", custom_lib_dir);
         println!("cargo:rustc-link-lib=static={}", custom_lib_name);


### PR DESCRIPTION
Makes libfuzzer_sys rebuild if the custom libfuzzer path changes and use the correct lib name if the library is double-prefixed ("liblib").