### PR TITLE
Allow "closure" body to be any expression, not only block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ pub fn initialize(_argc: *const isize, _argv: *const *const *const u8) -> isize 
 /// `"arbitrary-derive"` cargo feature.
 #[macro_export]
 macro_rules! fuzz_target {
-    (|$bytes:ident| $body:block) => {
+    (|$bytes:ident| $body:expr) => {
         const _: () = {
             /// Auto-generated function
             #[no_mangle]
@@ -244,15 +244,15 @@ macro_rules! fuzz_target {
         };
     };
 
-    (|$data:ident: &[u8]| $body:block) => {
+    (|$data:ident: &[u8]| $body:expr) => {
         $crate::fuzz_target!(|$data| $body);
     };
 
-    (|$data:ident: $dty: ty| $body:block) => {
-        $crate::fuzz_target!(|$data: $dty| -> () $body);
+    (|$data:ident: $dty:ty| $body:expr) => {
+        $crate::fuzz_target!(|$data: $dty| -> () { $body });
     };
 
-    (|$data:ident: $dty: ty| -> $rty: ty $body:block) => {
+    (|$data:ident: $dty:ty| -> $rty:ty $body:block) => {
         const _: () = {
             /// Auto-generated function
             #[no_mangle]


### PR DESCRIPTION
The `fuzz_target!` macro's input is designed to follow Rust's closure syntax, and mimics nearly all the syntax features of Rust closures: optional argument type, optional return type. 

However, it diverged from Rust closures in requiring the body of the "closure" to always be surrounded in curly braces, due to the use of $:block.

I had a fuzz target where I had to end up doing the following:

```rust
fuzz_target!(|bytes: &[u8]| { do_fuzz(bytes, true) });
```

The braces here diverge from how the equivalent closure would ordinarily be written. Punctuation which is required but doesn't serve a purpose detracts from the readability of the program.

This PR makes the braces around a "closure" body optional.

```rust
fuzz_target!(|bytes: &[u8]| do_fuzz(bytes, true));
```