### PR TITLE
Make it possible to link to custom runtime in another dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ once_cell = "1"
 cc = { version = "1.0", features = ["parallel"] }
 
 [features]
+default = ["link"]
+link = []
 arbitrary-derive = ["arbitrary/derive"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ once_cell = "1"
 cc = { version = "1.0", features = ["parallel"] }
 
 [features]
-default = ["link"]
-link = []
+default = ["link_libfuzzer"]
+link_libfuzzer = []
 arbitrary-derive = ["arbitrary/derive"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ And finally, run the fuzzer:
 $ ./target/debug/fuzzed
 ```
 
+### Linking to a local libfuzzer
+
+When using `libfuzzer-sys`, you can provide your own `libfuzzer` runtime in two ways.
+
+If you are developing a fuzzer, you can set the `CUSTOM_LIBFUZZER_PATH` environment variable to the path of your local
+libfuzzer runtime, which will then be linked instead of building libfuzzer as part of the build stage of `libfuzzer-sys`.
+For an example, to link to a prebuilt LLVM 16 libfuzzer, you could use:
+
+```bash
+$ export CUSTOM_LIBFUZZER_PATH=/usr/lib64/clang/16/lib/libclang_rt.fuzzer-x86_64.a
+$ cargo fuzz run ...
+```
+
+Alternatively, you may also disable the default `link_libfuzzer` feature:
+
+In `Cargo.toml`:
+```toml
+[dependencies]
+libfuzzer-sys = { path = "../../libfuzzer", default-features = false }
+```
+
+Then link to your own runtime in your `build.rs`.
+
 ## Updating libfuzzer from upstream
 
 ```

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ $ ./target/debug/fuzzed
 When using `libfuzzer-sys`, you can provide your own `libfuzzer` runtime in two ways.
 
 If you are developing a fuzzer, you can set the `CUSTOM_LIBFUZZER_PATH` environment variable to the path of your local
-libfuzzer runtime, which will then be linked instead of building libfuzzer as part of the build stage of `libfuzzer-sys`.
-For an example, to link to a prebuilt LLVM 16 libfuzzer, you could use:
+`libfuzzer` runtime, which will then be linked instead of building libfuzzer as part of the build stage of `libfuzzer-sys`.
+For an example, to link to a prebuilt LLVM 16 `libfuzzer`, you could use:
 
 ```bash
 $ export CUSTOM_LIBFUZZER_PATH=/usr/lib64/clang/16/lib/libclang_rt.fuzzer-x86_64.a

--- a/build.rs
+++ b/build.rs
@@ -1,42 +1,46 @@
-fn main() {
-    if cfg!(feature = "link") {
-        println!("cargo:rerun-if-env-changed=CUSTOM_LIBFUZZER_PATH");
-        if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
-            println!("cargo:rerun-if-changed={custom}");
+fn build_and_link_libfuzzer() {
+    println!("cargo:rerun-if-env-changed=CUSTOM_LIBFUZZER_PATH");
+    if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
+        println!("cargo:rerun-if-changed={custom}");
 
-            let custom_lib_path = ::std::path::PathBuf::from(&custom);
-            let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
+        let custom_lib_path = ::std::path::PathBuf::from(&custom);
+        let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
 
-            let custom_lib_name = custom_lib_path.file_stem().unwrap().to_string_lossy();
-            let custom_lib_name = custom_lib_name
-                .strip_prefix("lib")
-                .unwrap_or(custom_lib_name.as_ref());
+        let custom_lib_name = custom_lib_path.file_stem().unwrap().to_string_lossy();
+        let custom_lib_name = custom_lib_name
+            .strip_prefix("lib")
+            .unwrap_or(custom_lib_name.as_ref());
 
-            println!("cargo:rustc-link-search=native={}", custom_lib_dir);
-            println!("cargo:rustc-link-lib=static={}", custom_lib_name);
+        println!("cargo:rustc-link-search=native={}", custom_lib_dir);
+        println!("cargo:rustc-link-lib=static={}", custom_lib_name);
 
-            match std::env::var("CUSTOM_LIBFUZZER_STD_CXX") {
-                // Default behavior for backwards compat.
-                Err(_) => println!("cargo:rustc-link-lib=stdc++"),
-                Ok(s) if s == "none" => (),
-                Ok(s) => println!("cargo:rustc-link-lib={}", s),
-            }
-        } else {
-            let mut build = cc::Build::new();
-            let sources = ::std::fs::read_dir("libfuzzer")
-                .expect("listable source directory")
-                .map(|de| de.expect("file in directory").path())
-                .filter(|p| p.extension().map(|ext| ext == "cpp") == Some(true))
-                .collect::<Vec<_>>();
-            for source in sources.iter() {
-                println!("cargo:rerun-if-changed={}", source.display());
-                build.file(source.to_str().unwrap());
-            }
-            build.flag("-std=c++17");
-            build.flag("-fno-omit-frame-pointer");
-            build.flag("-w");
-            build.cpp(true);
-            build.compile("libfuzzer.a");
+        match std::env::var("CUSTOM_LIBFUZZER_STD_CXX") {
+            // Default behavior for backwards compat.
+            Err(_) => println!("cargo:rustc-link-lib=stdc++"),
+            Ok(s) if s == "none" => (),
+            Ok(s) => println!("cargo:rustc-link-lib={}", s),
         }
+    } else {
+        let mut build = cc::Build::new();
+        let sources = ::std::fs::read_dir("libfuzzer")
+            .expect("listable source directory")
+            .map(|de| de.expect("file in directory").path())
+            .filter(|p| p.extension().map(|ext| ext == "cpp") == Some(true))
+            .collect::<Vec<_>>();
+        for source in sources.iter() {
+            println!("cargo:rerun-if-changed={}", source.display());
+            build.file(source.to_str().unwrap());
+        }
+        build.flag("-std=c++17");
+        build.flag("-fno-omit-frame-pointer");
+        build.flag("-w");
+        build.cpp(true);
+        build.compile("libfuzzer.a");
+    }
+}
+
+fn main() {
+    if cfg!(feature = "link_libfuzzer") {
+        build_and_link_libfuzzer();
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,40 +1,42 @@
 fn main() {
-    println!("cargo:rerun-if-env-changed=CUSTOM_LIBFUZZER_PATH");
-    if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
-        println!("cargo:rerun-if-changed={custom}");
+    if cfg!(feature = "link") {
+        println!("cargo:rerun-if-env-changed=CUSTOM_LIBFUZZER_PATH");
+        if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
+            println!("cargo:rerun-if-changed={custom}");
 
-        let custom_lib_path = ::std::path::PathBuf::from(&custom);
-        let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
+            let custom_lib_path = ::std::path::PathBuf::from(&custom);
+            let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
 
-        let custom_lib_name = custom_lib_path.file_stem().unwrap().to_string_lossy();
-        let custom_lib_name = custom_lib_name
-            .strip_prefix("lib")
-            .unwrap_or(custom_lib_name.as_ref());
+            let custom_lib_name = custom_lib_path.file_stem().unwrap().to_string_lossy();
+            let custom_lib_name = custom_lib_name
+                .strip_prefix("lib")
+                .unwrap_or(custom_lib_name.as_ref());
 
-        println!("cargo:rustc-link-search=native={}", custom_lib_dir);
-        println!("cargo:rustc-link-lib=static={}", custom_lib_name);
+            println!("cargo:rustc-link-search=native={}", custom_lib_dir);
+            println!("cargo:rustc-link-lib=static={}", custom_lib_name);
 
-        match std::env::var("CUSTOM_LIBFUZZER_STD_CXX") {
-            // Default behavior for backwards compat.
-            Err(_) => println!("cargo:rustc-link-lib=stdc++"),
-            Ok(s) if s == "none" => (),
-            Ok(s) => println!("cargo:rustc-link-lib={}", s),
+            match std::env::var("CUSTOM_LIBFUZZER_STD_CXX") {
+                // Default behavior for backwards compat.
+                Err(_) => println!("cargo:rustc-link-lib=stdc++"),
+                Ok(s) if s == "none" => (),
+                Ok(s) => println!("cargo:rustc-link-lib={}", s),
+            }
+        } else {
+            let mut build = cc::Build::new();
+            let sources = ::std::fs::read_dir("libfuzzer")
+                .expect("listable source directory")
+                .map(|de| de.expect("file in directory").path())
+                .filter(|p| p.extension().map(|ext| ext == "cpp") == Some(true))
+                .collect::<Vec<_>>();
+            for source in sources.iter() {
+                println!("cargo:rerun-if-changed={}", source.display());
+                build.file(source.to_str().unwrap());
+            }
+            build.flag("-std=c++17");
+            build.flag("-fno-omit-frame-pointer");
+            build.flag("-w");
+            build.cpp(true);
+            build.compile("libfuzzer.a");
         }
-    } else {
-        let mut build = cc::Build::new();
-        let sources = ::std::fs::read_dir("libfuzzer")
-            .expect("listable source directory")
-            .map(|de| de.expect("file in directory").path())
-            .filter(|p| p.extension().map(|ext| ext == "cpp") == Some(true))
-            .collect::<Vec<_>>();
-        for source in sources.iter() {
-            println!("cargo:rerun-if-changed={}", source.display());
-            build.file(source.to_str().unwrap());
-        }
-        build.flag("-std=c++17");
-        build.flag("-fno-omit-frame-pointer");
-        build.flag("-w");
-        build.cpp(true);
-        build.compile("libfuzzer.a");
     }
 }


### PR DESCRIPTION
We are implementing https://github.com/AFLplusplus/LibAFL/pull/981, but don't want to make too much impact on the downstream users of libfuzzer-sys. As a compromise, this PR adds a default feature, `link`, which, when enabled, links to the libfuzzer runtime or the CUSTOM_LIBFUZZER_RUNTIME. When not enabled, it does not link to the fuzzer runtime.

This allows us to link to a custom runtime in our own dependency while reusing the infrastructure already provided by libfuzzer-sys (namely, fuzz_target and custom_mutator). See an example of this use case here:
https://github.com/AFLplusplus/LibAFL/blob/libfuzzer/libafl_libfuzzer/build.rs
https://github.com/AFLplusplus/LibAFL/blob/libfuzzer/libafl_libfuzzer/Cargo.toml#L17