### PR TITLE
Mark internal, fuzzer hook functions as `unsafe`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,11 @@ extern "C" {
     fn LLVMFuzzerMutate(data: *mut u8, size: usize, max_size: usize) -> usize;
 }
 
+/// Do not use; only for LibFuzzer's consumption.
 #[doc(hidden)]
 #[export_name = "LLVMFuzzerTestOneInput"]
-pub fn test_input_wrap(data: *const u8, size: usize) -> i32 {
-    let test_input = ::std::panic::catch_unwind(|| unsafe {
+pub unsafe fn test_input_wrap(data: *const u8, size: usize) -> i32 {
+    let test_input = ::std::panic::catch_unwind(|| {
         let data_slice = ::std::slice::from_raw_parts(data, size);
         rust_fuzzer_test_input(data_slice)
     });


### PR DESCRIPTION
These functions define specific symbols that libfuzzer looks for, and are only intended to be called by libfuzzer and with the contract that it guarantees. So make sure they are `unsafe` and hidden from docs and all that.