### PR TITLE
update package license string to be spdx compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The rust-fuzz Project Developers"]
 description = "A wrapper around LLVM's libFuzzer runtime."
 edition = "2018"
-license = "MIT/Apache-2.0/NCSA"
+license = "(MIT OR Apache-2.0) AND NCSA"
 name = "libfuzzer-sys"
 readme = "./README.md"
 repository = "https://github.com/rust-fuzz/libfuzzer"


### PR DESCRIPTION
Using https://github.com/actions/dependency-review-action in https://github.com/Chia-Network/chia_rs/actions/runs/11807687782/job/32894842447?pr=785 I got an error stating that the existing license short text `MIT/Apache-2.0/NCSA` is invalid from an SPDX perspective.

```
Licenses
  Warning: 
  The validity of the licenses of the dependencies below could not be determined. Ensure that they are valid SPDX licenses:
  Cargo.lock » libfuzzer-sys@0.4.8 – License: MIT/Apache-2.0/NCSA
  Error: Dependency review could not detect the validity of all licenses.
```

There was discussion with respect to Rust at https://github.com/rust-lang/cargo/issues/2174#issuecomment-355454163 and there are SPDX examples at https://spdx.dev/learn/handling-license-info/.