### PR TITLE
Add MSVC-Syntax C++17 Compiler Argument for Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,19 @@ fn build_and_link_libfuzzer() {
             println!("cargo:rerun-if-changed={}", source.display());
             build.file(source.to_str().unwrap());
         }
-        build.flag("-std=c++17");
+
+        // On Windows, the MSVC compiler has a different flag syntax for setting the C++ version.
+        // If we're building on Windows, use `/std:c++17`. Otherwise, use the Linux-friendly
+        // syntax. See this link for information on the MSVC option:
+        //
+        // https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
+        if cfg!(target_os = "windows") {
+            build.flag("/std:c++17");
+        }
+        else {
+            build.flag("-std=c++17");
+        }
+
         build.flag("-fno-omit-frame-pointer");
         build.flag("-w");
         build.cpp(true);


### PR DESCRIPTION
While the ability to build `libfuzzer-sys` on Windows systems is already supported and does indeed work, there are certain build environments on Windows where the C++17 standard is not chosen by default. When this happens, errors like this may occur during build:

```
libfuzzer\FuzzerLoop.cpp(802): error C2039: 'clamp': is not a member of 'std'
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\include\mutex(29): note: see declaration of 'std'
libfuzzer\FuzzerLoop.cpp(802): error C3861: 'clamp': identifier not found
```

The C++17 standard is selected in the current `build.rs` script, but because it's written in GCC-friendly syntax (`-std=c++17`), MSVC ignores it and doesn't apply the preference (warning D9002):

```
cl : Command line warning D9002 : ignoring unknown option '-std=c++17'
```

This PR adds code that checks for builds on a Windows system and instead uses the MSVC-friendly syntax (`/std:c++17`). When not on Windows, the original `-std=c++17` is still used. (See [this page](https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version) for information on the MSVC `/std` option.)

### Temporary Workaround for Devs

For anyone else facing this issue, a temporary workaround is to set the `CL` environment variable to specify the `/std:c++17` argument; this will pass it to the compiler. (See [here](https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables) for more information)

```powershell
$env:CL = "/std:c++17"
```