### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,3 +34,25 @@ jobs:
 
     - name: Run tests
       run: ./ci/script.sh
+  verify_package:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            windows-latest,
+            macos-15,
+            macos-15-intel,
+            ubuntu-24.04-arm,
+            windows-11-arm,
+          ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+      - name: Verify that the package includes all necessary files
+        run: cargo +stable package --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,17 @@ name = "libfuzzer-sys"
 readme = "./README.md"
 repository = "https://github.com/rust-fuzz/libfuzzer"
 version = "0.4.10"
+include = [
+    "README.md", 
+    "CHANGELOG.md", 
+    "LICENSE-MIT", 
+    "LICENSE-APACHE", 
+    "build.rs", 
+    "src/**/*.rs",
+    "libfuzzer/**/*.cpp",
+    "libfuzzer/**/*.h",
+    "libfuzzer/**/*.def",
+]
 
 [dependencies]
 arbitrary = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ name = "libfuzzer-sys"
 readme = "./README.md"
 repository = "https://github.com/rust-fuzz/libfuzzer"
 version = "0.4.10"
-include = [
-    "README.md", 
-    "CHANGELOG.md", 
-    "LICENSE-MIT", 
-    "LICENSE-APACHE", 
-    "build.rs", 
-    "src/**/*.rs",
-    "libfuzzer/**/*.cpp",
-    "libfuzzer/**/*.h",
-    "libfuzzer/**/*.def",
+exclude = [
+    ".github",
+    "ci",
+    "libfuzzer/CMakeLists.txt", # no cmake used
+    "libfuzzer/build.sh", # we use the cc crate for building
+    "libfuzzer/scripts/unbalanced_allocs.py",
+    "libfuzzer/standalone/StandaloneFuzzTargetMain.c", # that's the main function, we don't want it
+    "libfuzzer/tests/CMakeLists.txt",
+    "rust-toolchain", # downstream crates will ignore it anyway
+    "update-libfuzzer.sh", # there is no need for downstream crates to execute this script
 ]
 
 [dependencies]


### PR DESCRIPTION
During a dependency review we noticed that the libfuzzer crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.