### PR TITLE
Update rand/flate deps, improve rand algos. edition 2024 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Released YYYY-MM-DD.
 
 ### Changed
 
-* TODO (or remove section if none)
+* Recommend `SmallRng` over `StdRng` in the examples for faster, more lightweight
+  seeding and sampling
+* Updated `rand` dependency from 0.8.5 to 0.10
+* Updated `flate2` dependency from 1.0.24 to 1.1
+* Rename `gen` variable to `rng` for better 2024 Edition compatability
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ members = [
 ]
 
 [dev-dependencies]
-flate2 = "1.0.24"
-rand = "0.8.5"
+flate2 = "1.1"
+rand = { version = "0.10", default-features = false }

--- a/example_crossover/Cargo.toml
+++ b/example_crossover/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["R. Elliott Childre"]
 edition = "2021"
 
 [target.'cfg(fuzzing)'.dependencies]
-rand = "0.8"
+rand = { version = "0.10", default-features = false }

--- a/example_crossover/fuzz/Cargo.toml
+++ b/example_crossover/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-rand = "0.8"
+rand = { version = "0.10", default-features = false }
 libfuzzer-sys = { path = "../.." }
 example_crossover = { path = ".." }
 

--- a/example_mutator/Cargo.toml
+++ b/example_mutator/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-flate2 = "1.0.20"
+flate2 = "1.1"

--- a/example_mutator/fuzz/Cargo.toml
+++ b/example_mutator/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-flate2 = "1.0.24"
+flate2 = "1.1"
 libfuzzer-sys = { path = "../.." }
 
 [[bin]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,17 +409,17 @@ macro_rules! fuzz_target {
 /// ```no_run
 /// #![no_main]
 ///
-/// use rand::{rngs::StdRng, Rng, SeedableRng};
+/// use rand::{rngs::SmallRng, RngExt, SeedableRng};
 ///
 /// libfuzzer_sys::fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
-///     let mut rng = StdRng::seed_from_u64(seed as u64);
+///     let mut rng = SmallRng::seed_from_u64(seed as u64);
 ///
 /// #   let first_mutation = |_, _, _, _| todo!();
 /// #   let second_mutation = |_, _, _, _| todo!();
 /// #   let third_mutation = |_, _, _, _| todo!();
 /// #   let fourth_mutation = |_, _, _, _| todo!();
 ///     // Choose which of our four supported kinds of mutations we want to make.
-///     match rng.gen_range(0..4) {
+///     match rng.random_range(0..4) {
 ///         0 => first_mutation(rng, data, size, max_size),
 ///         1 => second_mutation(rng, data, size, max_size),
 ///         2 => third_mutation(rng, data, size, max_size),
@@ -632,7 +632,7 @@ pub fn fuzzer_mutate(data: &mut [u8], size: usize, max_size: usize) -> usize {
 /// #![no_main]
 ///
 /// use libfuzzer_sys::{fuzz_crossover, fuzz_mutator, fuzz_target, fuzzer_mutate};
-/// use rand::{rngs::StdRng, Rng, SeedableRng};
+/// use rand::{rngs::SmallRng, RngExt, SeedableRng};
 /// use std::mem::size_of;
 ///
 /// fuzz_target!(|data: &[u8]| {
@@ -651,11 +651,11 @@ pub fn fuzzer_mutate(data: &mut [u8], size: usize, max_size: usize) -> usize {
 /// // Inject some ...potentially problematic values to make the example close
 /// // more quickly.
 /// fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
-///     let mut gen = StdRng::seed_from_u64(seed.into());
+///     let mut rng = SmallRng::seed_from_u64(seed.into());
 ///
 ///     let (_, floats, _) = unsafe { data[..size].align_to_mut::<f64>() };
 ///
-///     let x = gen.gen_range(0..=1000);
+///     let x = rng.random_range(0..=1000);
 ///     if x == 0 && !floats.is_empty() {
 ///         floats[0] = f64::INFINITY;
 ///     } else if x == 1000 && floats.len() > 1 {


### PR DESCRIPTION
* Update rust rand to new 0.10 release
  * remove default features that are not needed for strong randomness that is overkill for simple seeding and fetching values
  * Move to SmallRng over StdRng for memory efficiency, and faster CI builds with fewer dependencies
* Update flate to 1.1 release
* remove `gen` variable as it is now a reserved word in the 2024 edition